### PR TITLE
chore: use self-hosted runner for Swift interfaces

### DIFF
--- a/.github/workflows/generate-swiftinterface.yml
+++ b/.github/workflows/generate-swiftinterface.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   generate:
     name: Generate ${{ inputs.platform }}
-    runs-on: ${{ (inputs.platform == 'linux' || inputs.platform == 'wasi') && 'ubuntu-latest' || inputs.platform == 'windows' && 'windows-latest' || 'macos-latest' }}
+    runs-on: ${{ (inputs.platform == 'linux' || inputs.platform == 'wasi') && 'ubuntu-latest' || inputs.platform == 'windows' && 'windows-latest' || 'self-hosted' }}
     env:
       GH_TOKEN: ${{ github.token }}
       INPUT_TARGET_BRANCH: ${{ inputs.target_branch }}


### PR DESCRIPTION
## Summary

- run Apple-platform Swift interface generation on the configured self-hosted runner
- keep Linux/WASI generation on GitHub-hosted Ubuntu and Windows generation on GitHub-hosted Windows

## Why

The self-hosted macOS runner can use the machine's existing environment for Apple-platform builds. This also provides a temporary path for packages with private dependencies until a dedicated cross-repository token is configured.

## Validation

- YAML parsed successfully
- diff contains only the `runs-on` expression in `generate-swiftinterface.yml`
